### PR TITLE
修复: 用户消息里带图片时，图片以文字方式展示

### DIFF
--- a/plugin.client.js
+++ b/plugin.client.js
@@ -474,6 +474,16 @@ function imageCount(content) {
   return n;
 }
 
+function imageParts(content) {
+  if (!Array.isArray(content)) return [];
+  const out = [];
+  for (let i = 0; i < content.length; i++) {
+    const block = content[i];
+    if (block && block.type === 'image' && block.attachment) out.push({ attachment: block.attachment });
+  }
+  return out;
+}
+
 function clip(text, max) {
   const t = String(text).replace(/\s+/g, ' ').trim();
   return t.length > max ? t.slice(0, max - 1) + '…' : t;
@@ -1016,6 +1026,7 @@ return {
       const data = node.data || {};
       const text = contentText(data.content);
       const images = imageCount(data.content);
+      const messageImages = imageParts(data.content);
       const sessionId = props.sessionId !== undefined ? props.sessionId : (node.sessionId);
       // location.turn is a turn-group object ({turn, start, end, steps}); the
       // turn number lives one level down.
@@ -1207,7 +1218,12 @@ return {
         React.createElement('div', { className: 'mtx-line' },
           React.createElement('div', { className: 'mtx-bubble' },
             text,
-            images > 0 ? React.createElement('div', { className: 'mtx-img' }, t('images', { count: images })) : null
+            // The host renders attachments through its images slot (native
+            // gallery plus lightbox); keep the placeholder only when the slot
+            // owner props do not carry the callback.
+            messageImages.length > 0 && typeof props.renderMessageImages === 'function'
+              ? props.renderMessageImages({ images: messageImages, align: 'end' })
+              : (images > 0 ? React.createElement('div', { className: 'mtx-img' }, t('images', { count: images })) : null)
           )
         ),
         // The controls sit under the bubble in all three references. Which


### PR DESCRIPTION
## 问题

用户消息里带图片时，气泡里只显示 "{count} image(s) kept as-is" 占位文案，图片不显示。
<img width="216" height="96" alt="image" src="https://github.com/user-attachments/assets/150d7304-5242-48b7-af12-c1f30a96e8ef" />


## 原因

本插件接管了用户气泡的渲染，但没实现图片渲染。宿主其实已经提供了
`renderMessageImages` 回调（原生图片画廊 + 点击看原图），之前没有用它。

## 修复

气泡里有图片时改为调用dsh原生的 `renderMessageImages`，由宿主渲染图片；
宿主没提供回调时，退回原来的占位文案。恢复与dsh原始图片处理

编辑框里的占位文案保持不变（编辑时不显示图片是预期交互）。
